### PR TITLE
Prevent admin pages from being saved

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Staticfilecache
-version: 1.0.1
+version: 1.0.2
 description: Simple static file cache solution
 icon: paper-plane 
 author:

--- a/staticfilecache.php
+++ b/staticfilecache.php
@@ -55,6 +55,7 @@ class StaticfilecachePlugin extends Plugin
     {
         if ($this->isAdmin()) {
             $this->active = false;
+            return;
         }
 
         if (!self::$writeCache) {


### PR DESCRIPTION
At the moment admin pages are also being saved to file, which isn't ideal, as for example you can't even log in
